### PR TITLE
Addition of a toggleable visibility for item cost

### DIFF
--- a/campaign/record_item.xml
+++ b/campaign/record_item.xml
@@ -32,6 +32,8 @@
 						window.update();
 					end
 				</script>
+				<gmeditonly />
+				<gmvisibleonly />
 			</buttonfield>
 			
 			<label_column name="charge_label" insertbefore="divider4">

--- a/campaign/record_item.xml
+++ b/campaign/record_item.xml
@@ -17,7 +17,23 @@
 	<windowclass name="item_main" merge="join">
 		<margins control="0,0,0,2" />
 		<script file="campaign/scripts/item_main.lua" />
-		<sheetdata>	
+		<sheetdata>
+			<string_columnh name="cost">
+				<anchored>
+					<right offset="-30" />
+				</anchored>
+			</string_columnh>
+			<buttonfield name="cost_visibility" insertbefore="weight_label">
+				<anchored to="cost" position="right" offset="10,0" width="20" />
+				<state icon="visibilityon" />>
+				<state icon="visibilityoff" />
+				<script>
+					function onValueChanged()
+						window.update();
+					end
+				</script>
+			</buttonfield>
+			
 			<label_column name="charge_label" insertbefore="divider4">
 				<anchored>
 					<top offset="16" />

--- a/campaign/scripts/item_main.lua
+++ b/campaign/scripts/item_main.lua
@@ -34,6 +34,7 @@ function update()
 	local nodeRecord = getDatabaseNode();
 	local bReadOnly = WindowManager.getReadOnlyState(nodeRecord);
 	local bID, bOptionID = ItemManager.getIDState(nodeRecord);
+	local nCostVisibility = cost_visibility.getValue();
 
 	local bWeapon, bArmor, bShield, bWand, bStaff, bWondrous = getItemType();
 
@@ -54,7 +55,11 @@ function update()
 	if updateControl('subtype', bReadOnly, bID) then bSection2 = true; end
 
 	local bSection3 = false;
-	if updateControl('cost', bReadOnly, bID) then bSection3 = true; end
+	if Session.IsHost then
+		if updateControl("cost", bReadOnly, bID) then bSection3 = true; end
+	else
+		if updateControl("cost", bReadOnly, bID and (nCostVisibility == 0)) then bSection3 = true; end
+	end
 	if updateControl('weight', bReadOnly, bID) then bSection3 = true; end
 	if updateControl('size', bReadOnly, bID) then bSection3 = true; end
 


### PR DESCRIPTION
- Only the GM can see and edit the visibility
- The visibility gets saved to the DB. Only non read-only entries can be changed.
- The selling function of the party sheet still works